### PR TITLE
Add more explicit isNaN case

### DIFF
--- a/src/lib/predicates/isSome.ts
+++ b/src/lib/predicates/isSome.ts
@@ -1,7 +1,7 @@
 import { Predicate, Some } from '../types'
 
 /**
- * Checks if a value is a value other then `null` or `undefined`.
+ * Checks if a value is a value other then `null`, `undefined`, or not NaN.
  */
 export const isSome: Predicate<Some> = (value: unknown): value is Some =>
-  value != null && value === value
+  value != null && Number.isNaN(value) === false

--- a/src/lib/predicates/isSome.ts
+++ b/src/lib/predicates/isSome.ts
@@ -2,6 +2,9 @@ import { Predicate, Some } from '../types'
 
 /**
  * Checks if a value is a value other then `null`, `undefined`, or not NaN.
+ *
+ * Using `value === value` for the NaN check instead of `Number.isNaN(value) === false` 
+ * because it's slightly faster (~1%).
  */
 export const isSome: Predicate<Some> = (value: unknown): value is Some =>
-  value != null && Number.isNaN(value) === false
+  value != null && value === value


### PR DESCRIPTION
It wasn't clear from the JSDoc and code that the `value === value` condition is used to check for not `NaN` values